### PR TITLE
Use internal methods instead of service methods directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ You can run this example with `npm run example` from the cloned repository and g
 
 ## Changelog
 
+__0.6.0__
+
+- Use internal methods instead of service methods directly
+
 __0.4.0/0.5.0__
 
 - Migrate to new ES6 plugin infrastructure and support all advanced querying mechanisms ([#10](https://github.com/feathersjs/feathers-memory/pull/10))


### PR DESCRIPTION
This is for https://github.com/feathersjs/feathers/issues/218. Basically, if an adapter uses its own service methods internally (like doing a `get` after removing an item) they can't be the original service methods (like `get`, `create`, `find` etc.) directly since those can be modified by Feathers with mixins and hooks and we do not want those to run in that case. The solution is to provide internal `_patch`, `_create`, `_find` etc. methods that can be used instead.