### PR TITLE
bumping feathers-errors version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.2.0",
-    "feathers-errors": "^1.2.3",
+    "feathers-errors": "^2.0.0",
     "feathers-query-filters": "^1.1.1",
     "lodash": "^3.10.1",
     "uberproto": "^1.2.0"


### PR DESCRIPTION
This is required so that we can use feathers-memory (which is required by feathers-localstorage) in the browser or React Native.