### PR TITLE
Two tweaks for clean build and tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "compile": "rm -rf lib/ && babel -d lib/ src/",
+    "compile": "rimraf lib/ && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "lint": "eslint-if-supported semistandard --fix",
     "mocha": "mocha --opts mocha.opts",
@@ -67,6 +67,7 @@
     "feathers-socketio": "^1.3.3",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^3.0.0",
+    "rimraf": "^2.5.2",
     "semistandard": "^9.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "watch": "babel --watch -d lib/ src/",
     "lint": "eslint-if-supported semistandard --fix",
     "mocha": "mocha --opts mocha.opts",
-    "coverage": "istanbul cover _mocha -- --opts mocha.opts",
+    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
     "test": "npm run compile && npm run lint && npm run coverage",
     "start": "node example/app.js"
   },


### PR DESCRIPTION
- Updated the platform-dependent `rm` with `rimraf` to fix `npm test` errors on Windows.
- Fixed relative `_mocha` path to resolve errors on `npm test` (actually `npm run coverage`).