### PR TITLE
fix $select with more than one field

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ class Service {
     }
 
     if (filters.$select) {
-      values = values.map(value => _.pick(value, filters.$select));
+      values = values.map(value => _.pick(value, ...filters.$select));
     }
 
     return Promise.resolve({


### PR DESCRIPTION
```js
console.log(await service.find({
	query: {
		$select: ['id', 'name']
	}
})); // [ { 'id,name': undefined }, { 'id,name': undefined } ]
```