### PR TITLE
Deep clone objects before returning

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "babel-plugin-add-module-exports": "^0.2.0",
     "babel-preset-es2015": "^6.18.0",
     "body-parser": "^1.14.1",
+    "clone-deep": "^1.0.0",
     "eslint-if-supported": "^1.0.1",
     "feathers": "^2.0.0-pre.4",
     "feathers-rest": "^1.2.2",

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ class Service {
   // a pagination object
   _find (params, getFilter = filter) {
     const { query, filters } = getFilter(params.query || {});
+    const map = select(params, this.id);
     let values = _.values(this.store).filter(this._matcher(query));
 
     const total = values.length;
@@ -51,7 +52,7 @@ class Service {
       total,
       limit: filters.$limit,
       skip: filters.$skip || 0,
-      data: select(params, this.id)(values)
+      data: map(values)
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ class Service {
       total,
       limit: filters.$limit,
       skip: filters.$skip || 0,
-      data: values.map(select(params, this.id))
+      data: select(params, this.id)(values)
     });
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -60,6 +60,23 @@ describe('Feathers Memory Service', () => {
     });
   });
 
+  it('does not modify the original data', () => {
+    const people = app.service('people');
+
+    return people.create({
+      name: 'Delete tester',
+      age: 33
+    }).then(person => {
+      delete person.age;
+
+      return people.get(person.id);
+    }).then(person => {
+      assert.equal(person.age, 33);
+
+      return people.remove(person.id);
+    });
+  });
+
   base(app, errors);
   base(app, errors, 'people-customid', 'customid');
 });


### PR DESCRIPTION
This caused issues before because it was returning the in-memory object so if you modified it (e.g. with a `remove` hook), the version in the database was also being modified.