### PR TITLE
Modified matcher to use new sift package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1170,7 +1170,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-1.0.0.tgz",
       "integrity": "sha512-hmJRX8x1QOJVV+GUjOBzi6iauhPqc9hIF6xitWRBbiPZOBb6vGo/mDRIK9P74RTKSQK7AE8B0DDWY/vpRrPmQw==",
-      "dev": true,
       "requires": {
         "for-own": "1.0.0",
         "is-plain-object": "2.0.4",
@@ -1182,7 +1181,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-          "dev": true,
           "requires": {
             "for-in": "1.0.2"
           }
@@ -1190,8 +1188,7 @@
         "kind-of": {
           "version": "5.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
+          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw=="
         }
       }
     },
@@ -1458,12 +1455,6 @@
       "requires": {
         "repeating": "2.0.1"
       }
-    },
-    "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-      "dev": true
     },
     "doctrine": {
       "version": "2.0.0",
@@ -2338,8 +2329,7 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "0.1.5",
@@ -3401,18 +3391,6 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
-    "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-      "dev": true
-    },
     "handlebars": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
@@ -3692,8 +3670,7 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "1.0.0",
@@ -3778,7 +3755,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "3.0.1"
       },
@@ -3786,8 +3762,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -4057,12 +4032,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -4177,79 +4146,11 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
     "lodash.cond": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
     },
     "longest": {
       "version": "1.0.1",
@@ -4346,7 +4247,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-      "dev": true,
       "requires": {
         "for-in": "0.1.8",
         "is-extendable": "0.1.1"
@@ -4355,8 +4255,7 @@
         "for-in": {
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
-          "dev": true
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
         }
       }
     },
@@ -4370,64 +4269,57 @@
       }
     },
     "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
         "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
+        "supports-color": "4.4.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
-        "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+        "diff": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+          "dev": true
+        },
+        "growl": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
         },
         "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -5286,7 +5178,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
       "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
-      "dev": true,
       "requires": {
         "is-extendable": "0.1.1",
         "kind-of": "5.0.2",
@@ -5296,8 +5187,7 @@
         "kind-of": {
           "version": "5.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
+          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw=="
         }
       }
     },
@@ -5311,6 +5201,11 @@
         "interpret": "1.0.3",
         "rechoir": "0.6.2"
       }
+    },
+    "sift": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-5.0.0.tgz",
+      "integrity": "sha1-IS7LQQ2KUbg+fZaeSdU+ZZAoX/o="
     },
     "slash": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -49,10 +49,11 @@
     "lib": "lib"
   },
   "dependencies": {
+    "clone-deep": "^1.0.0",
     "feathers-commons": "^0.8.0",
     "feathers-errors": "^2.0.1",
     "feathers-query-filters": "^2.0.0",
-    "clone-deep": "^1.0.0",
+    "sift": "^5.0.0",
     "uberproto": "^1.2.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,22 @@ import Proto from 'uberproto';
 import filter from 'feathers-query-filters';
 import errors from 'feathers-errors';
 import cloneDeep from 'clone-deep';
-import { sorter, matcher, select as baseSelect, _ } from 'feathers-commons';
+import { sorter, select as baseSelect, _ } from 'feathers-commons';
+import sift from 'sift';
 
 const select = (...args) => {
   const base = baseSelect(...args);
 
   return function (result) {
     return base(cloneDeep(result));
+  };
+};
+
+const matcher = query => {
+  return items => {
+    const s = Object.assign({}, query);
+    items = [].concat(items || []);
+    return !!sift(s, items).length;
   };
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ class Service {
     this._uId = options.startId || 0;
     this.store = options.store || {};
     this.events = options.events || [];
+    this._matcher = options.matcher;
     this._sorter = options.sorter || sorter;
   }
 
@@ -32,7 +33,13 @@ class Service {
   _find (params, getFilter = filter) {
     const { query, filters } = getFilter(params.query || {});
     const map = select(params, this.id);
-    let values = sift(query, _.values(this.store));
+    let values = _.values(this.store);
+
+    if (this._matcher) {
+      values = values.filter(this._matcher(query));
+    } else {
+      values = sift(query, values);
+    }
 
     const total = values.length;
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,14 +13,6 @@ const select = (...args) => {
   };
 };
 
-const matcher = query => {
-  return items => {
-    const s = Object.assign({}, query);
-    items = [].concat(items || []);
-    return !!sift(s, items).length;
-  };
-};
-
 class Service {
   constructor (options = {}) {
     this.paginate = options.paginate || {};
@@ -28,7 +20,6 @@ class Service {
     this._uId = options.startId || 0;
     this.store = options.store || {};
     this.events = options.events || [];
-    this._matcher = options.matcher || matcher;
     this._sorter = options.sorter || sorter;
   }
 
@@ -41,7 +32,7 @@ class Service {
   _find (params, getFilter = filter) {
     const { query, filters } = getFilter(params.query || {});
     const map = select(params, this.id);
-    let values = _.values(this.store).filter(this._matcher(query));
+    let values = sift(query, _.values(this.store));
 
     const total = values.length;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,34 +32,6 @@ describe('Feathers Memory Service', () => {
     )
   );
 
-  it('allows to pass custom find and sort matcher', () => {
-    let sorterCalled = false;
-    let matcherCalled = false;
-
-    app.use('/matcher', memory({
-      matcher () {
-        matcherCalled = true;
-        return function () {
-          return true;
-        };
-      },
-
-      sorter () {
-        sorterCalled = true;
-        return function () {
-          return 0;
-        };
-      }
-    }));
-
-    return app.service('matcher').find({
-      query: { $sort: { something: 1 } }
-    }).then(() => {
-      assert.ok(sorterCalled, 'sorter called');
-      assert.ok(matcherCalled, 'matcher called');
-    });
-  });
-
   it('does not modify the original data', () => {
     const people = app.service('people');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,10 +32,18 @@ describe('Feathers Memory Service', () => {
     )
   );
 
-  it('allows to pass custom sorter', () => {
+  it('allows to pass custom find and sort matcher', () => {
     let sorterCalled = false;
+    let matcherCalled = false;
 
-    app.use('/sorter', memory({
+    app.use('/matcher', memory({
+      matcher () {
+        matcherCalled = true;
+        return function () {
+          return true;
+        };
+      },
+
       sorter () {
         sorterCalled = true;
         return function () {
@@ -44,10 +52,11 @@ describe('Feathers Memory Service', () => {
       }
     }));
 
-    return app.service('sorter').find({
+    return app.service('matcher').find({
       query: { $sort: { something: 1 } }
     }).then(() => {
       assert.ok(sorterCalled, 'sorter called');
+      assert.ok(matcherCalled, 'matcher called');
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,6 +32,25 @@ describe('Feathers Memory Service', () => {
     )
   );
 
+  it('allows to pass custom sorter', () => {
+    let sorterCalled = false;
+
+    app.use('/sorter', memory({
+      sorter () {
+        sorterCalled = true;
+        return function () {
+          return 0;
+        };
+      }
+    }));
+
+    return app.service('sorter').find({
+      query: { $sort: { something: 1 } }
+    }).then(() => {
+      assert.ok(sorterCalled, 'sorter called');
+    });
+  });
+
   it('does not modify the original data', () => {
     const people = app.service('people');
 


### PR DESCRIPTION
Changed the `matcher` from the `feathers-commons` package to use the [sift](https://github.com/crcn/sift.js) package to allow for more refined query matching. 

This improves `$in` support to be more like `mongodb`.