### PR TITLE
Store key is now of type Id

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -186,6 +186,16 @@ describe('Feathers Memory Service', () => {
     }
   });
 
+  it('store ids that are not numbers', async () => {
+    const testCandy = { id: '00000000-0000-0000-0000-000000000000', name: 'Testing' };
+    const startCandies = [];
+    startCandies[testCandy.id] = testCandy;
+    app.use('/candy', memory({ store: startCandies }));
+    const candy = await app.service('candy').get(testCandy.id);
+
+    assert.deepStrictEqual(candy, testCandy);
+  });
+
   testSuite(app, errors, 'people');
   testSuite(app, errors, 'people-customid', 'customid');
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,9 +2,9 @@
 import { Params, Paginated, Id, NullableId } from '@feathersjs/feathers';
 import { AdapterService, ServiceOptions, InternalServiceMethods } from '@feathersjs/adapter-commons';
 
-export interface MemoryServiceStore {
-  [key: number]: any;
-}
+export type MemoryServiceStore = {
+  [key in Id]: any;
+};
 
 export interface MemoryServiceOptions extends ServiceOptions {
   store: MemoryServiceStore;


### PR DESCRIPTION
### Summary
It changed the type of store key to be of type Id instead of a number.
A maybe better way of solving this is to change internal logic to using an actual key in objects instead key in store. Then key or reader index in that array of objects, will not be used at all.

This pull request is related to https://github.com/feathersjs-ecosystem/feathers-memory/issues/117

I can do build and commit also those dist files, if needed.