### PR TITLE
Allow usage of $unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ __Options:__
 - `whitelist` (*optional*) - A list of additional query parameters to allow
 - `multi` (*optional*) - Allow `create` with arrays and `update` and `remove` with `id` `null` to change multiple items. Can be `true` for all methods or an array of allowed methods (e.g. `[ 'remove', 'create' ]`)
 
+Along with the common Feathers query syntax, this service also supports using the `$unset` data property similar to Mongo/Mongoose to delete properties. But, unlike Mongo/Mongoose it does not support dot notation.
+
+```js
+await service.patch(1, { $unset: { name: "" } });
+```
+
 ## Example
 
 Here is an example of a Feathers server with a `messages` in-memory service that supports pagination:

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,8 +101,20 @@ class Service extends AdapterService {
   async _patch (id, data, params = {}) {
     const patchEntry = entry => {
       const currentId = entry[this.id];
+      const { $unset, ...values } = data;
 
-      this.store[currentId] = _.extend(this.store[currentId], _.omit(data, this.id));
+      if ($unset) {
+        const unsets = _.keys($unset).filter(key => key !== this.id);
+        this.store[currentId] = _.extend(
+          _.omit(this.store[currentId], ...unsets),
+          _.omit(values, this.id)
+        );
+      } else {
+        this.store[currentId] = _.extend(
+          this.store[currentId],
+          _.omit(values, this.id)
+        );
+      }
 
       return _select(this.store[currentId], params, this.id);
     };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -113,6 +113,45 @@ describe('Feathers Memory Service', () => {
     await animals.remove(null, {});
   });
 
+  it('patch with $unset', async () => {
+    const people = app.service('people');
+    const person = await people.create({
+      name: 'Tester',
+      age: 33
+    });
+
+    const updatedPerson = await people.patch(person.id, {
+      $unset: { age: "" }
+    });
+
+    assert.strictEqual(typeof updatedPerson.age, 'undefined');
+
+    await people.remove(person.id);
+  });
+
+  it('patch with $unset multi', async () => {
+    app.use('/animals', memory({ multi: true }));
+    const animals = app.service('animals');
+    const animal1 = await animals.create({
+      name: 'Tester',
+      age: 33
+    });
+    const animal2 = await animals.create({
+      name: 'Tester',
+      age: 33
+    });
+
+    const [updated1, updated2] = await animals.patch(null, {
+      $unset: { age: "" }
+    });
+
+    assert.strictEqual(typeof updated1.age, 'undefined');
+    assert.strictEqual(typeof updated2.age, 'undefined');
+
+    await animals.remove(animal1.id);
+    await animals.remove(animal2.id);
+  });
+
   it('allows to pass custom find and sort matcher', async () => {
     let sorterCalled = false;
     let matcherCalled = false;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -121,7 +121,7 @@ describe('Feathers Memory Service', () => {
     });
 
     const updatedPerson = await people.patch(person.id, {
-      $unset: { age: "" }
+      $unset: { age: '' }
     });
 
     assert.strictEqual(typeof updatedPerson.age, 'undefined');
@@ -142,7 +142,7 @@ describe('Feathers Memory Service', () => {
     });
 
     const [updated1, updated2] = await animals.patch(null, {
-      $unset: { age: "" }
+      $unset: { age: '' }
     });
 
     assert.strictEqual(typeof updated1.age, 'undefined');


### PR DESCRIPTION
### Summary

Closes #120 

Note that this is not an exact match to Mongo/Mongoose `$unset`, mainly that it does not support dot.notation in the fields to unset. I think this is fine...it just uses the common `_.omit` function. 

Let me know any thoughts.