### PR TITLE
Use for loop in _find()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,28 +33,47 @@ class Service extends AdapterService {
     const { query, filters, paginate } = this.filterQuery(params);
     let values = _.values(this.store);
     const total = values.length;
+    const hasSkip = filters.$skip !== undefined;
+    const hasSort = filters.$sort !== undefined;
+    const hasLimit = filters.$limit !== undefined;
+    const hasQuery = _.keys(query).length > 0;
 
-    if (_.keys(query).length > 0) {
-      values = values.filter(this.options.matcher(query));
-    }
-
-    if (filters.$sort !== undefined) {
+    if (hasSort) {
       values.sort(this.options.sorter(filters.$sort));
     }
 
-    if (filters.$skip !== undefined) {
-      values = values.slice(filters.$skip);
-    }
+    if (hasQuery || hasLimit || hasSkip) {
+      let skipped = 0;
+      const matcher = this.options.matcher(query);
+      const matched = []
 
-    if (filters.$limit !== undefined) {
-      values = values.slice(0, filters.$limit);
+      for (let index = 0, length = values.length; index < length; index++) {
+        const value = values[index];
+
+        if (hasQuery && !matcher(value, index, values)) {
+          continue;
+        }
+
+        if (hasSkip && filters.$skip > skipped) {
+          skipped++;
+          continue;
+        }
+
+        matched.push(_select(value, params));
+
+        if (hasLimit && filters.$limit === matched.length) {
+          break;
+        }
+      }
+
+      values = matched;
     }
 
     const result = {
       total,
       limit: filters.$limit,
       skip: filters.$skip || 0,
-      data: values.map(value => _select(value, params))
+      data: filters.$limit === 0 ? [] : values
     };
 
     if (!(paginate && paginate.default)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ class Service extends AdapterService {
     if (hasQuery || hasLimit || hasSkip) {
       let skipped = 0;
       const matcher = this.options.matcher(query);
-      const matched = []
+      const matched = [];
 
       for (let index = 0, length = values.length; index < length; index++) {
         const value = values[index];

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,8 +31,12 @@ class Service extends AdapterService {
 
   async _find (params = {}) {
     const { query, filters, paginate } = this.filterQuery(params);
-    let values = _.values(this.store).filter(this.options.matcher(query));
+    let values = _.values(this.store);
     const total = values.length;
+
+    if (_.keys(query).length > 0) {
+      values = values.filter(this.options.matcher(query));
+    }
 
     if (filters.$sort !== undefined) {
       values.sort(this.options.sorter(filters.$sort));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -134,7 +134,7 @@ describe('Feathers Memory Service', () => {
     }));
 
     await app.service('matcher').find({
-      query: { $sort: { something: 1 } }
+      query: { name: 'somehting', $sort: { something: 1 } }
     });
 
     assert.ok(sorterCalled, 'sorter called');


### PR DESCRIPTION
This PR increases the performance of `_find()` by optimizing the way data is matched/limited. This is accomplished by using a `for` loop to handle multiple operations in the same loop instead of using filter/map/slice. 

## Problem
```js
// Given a service with 10,000 results and default pagination 10

// Current implementation
// 1 - Filters 10,000 results (even though no query)
// 2 - Slices to 10 results
// 3 - Maps to _select
const users = app.service('users').find():

// NEW implementation
// 1 - Returns first 10 results with select
const users = app.service('users').find():

// With query

// Current implementation
// 1 - Filters 10,000 results with query
// 2 - Slices to 10 results
// 3 - Maps to _select
const users = app.service('users').find({ query: { name: 'Bob' } }):

// NEW implementation
// 1 - Filters/select up to 10 results with query
// 2 - Returns 10 results
const users = app.service('users').find({ query: { name: 'Bob' } }):

// With limit/skip

// Current implementation
// 1 - Filters 10,000 results with query
// 2 - Skips to 20 results
// 3 - Slices to 20 results
// 4 - Maps to _select
const users = app.service('users').find({ query: { name: 'Bob', $limit: 20, $skip: 20 } }):

// NEW implementation
// 1 - Filters/skip/limit/select up to 20 results with query
// 2 - Returns 20 results
const users = app.service('users').find({ query: { name: 'Bob', $limit: 20, $skip: 20 } }):


```


## Pros
- Unlike `filter`, the `for` loop allows us to `break` after `$limit` number of matches, which means we do not run the matcher on results that would have been discarded later via skip/limit.
- Does not require an extra map to select results. `values = values.map(value => _select(value, params))` is no longer needed because the `_select` also happens in the for loop.
- Less memory. This is negligible, but this approach also uses less arrays/memory by removing the multiple `array.slice` used to handle skip/limit.

## Cons
- Arguably more complicated. And because `feathers-memory` is often used as an example in the feathers ecosystem, this package should be simple.

If we don't choose to adopt this whole PR, I do feel strongly that we should at least implement 1cc816429b6d29fa33e15077a815fabf2c964a54 which is a very simple change that skips initial `filter` if there is no query.
